### PR TITLE
Use React Dnd instead of React-Draggable library (Unstable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "dependencies": {
     "grid-breakpoint": "^1.7.0",
     "lodash.pickby": "^4.6.0",
+    "react-dnd": "^7.3.2",
     "react-draggable": "^3.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "dependencies": {
     "grid-breakpoint": "^1.7.0",
     "lodash.pickby": "^4.6.0",
-    "react-dnd": "^7.3.2",
-    "react-draggable": "^3.0.5"
+    "react-dnd": "^7.3.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -191,34 +191,30 @@ class GridDraggable extends Component<DraggableProps, DraggableState> {
     return null;
   }
 
-  swapGrid(data: ReactDraggableCallbackData, fromKey: number) {
+  swapGrid(fromKey: number, toKey: number) {
     const {onSwap} = this.props;
     const {children} = this.state;
-    const filterGrid = this.matchGrid(data);
 
-    if (filterGrid.length > 0) {
-      // create new array for children.
-      const newChildren = children.slice();
-      const toKey = filterGrid[0].key;
+    // create new array for children.
+    const newChildren = children.slice();
 
-      if (fromKey !== undefined && toKey !== undefined) {
-        const fromIndex = children.findIndex(child =>
-          child.props.gridKey === fromKey);
-        const toIndex = children.findIndex(child =>
-          child.props.gridKey === toKey);
-        const tmp = newChildren[fromIndex];
-        newChildren[fromIndex] = newChildren[toIndex];
-        newChildren[toIndex] = tmp;
+    if (fromKey !== undefined && toKey !== undefined) {
+      const fromIndex = children.findIndex(child =>
+        child.props.gridKey === fromKey);
+      const toIndex = children.findIndex(child =>
+        child.props.gridKey === toKey);
+      const tmp = newChildren[fromIndex];
+      newChildren[fromIndex] = newChildren[toIndex];
+      newChildren[toIndex] = tmp;
 
-        if (onSwap) {
-          onSwap(fromIndex, toIndex);
-        }
+      if (onSwap) {
+        onSwap(fromIndex, toIndex);
       }
-
-      this.setState({
-        children: newChildren
-      });
     }
+
+    this.setState({
+      children: newChildren
+    });
   }
 
   setBounding(key: string, bound: DOMRect, ref: Section) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // @flow
 import * as React from 'react';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
 import GridBreakpoint from 'grid-breakpoint';
 import pickBy from 'lodash.pickby';
 import type Section from './section';
@@ -30,7 +32,7 @@ type BoundKey = {
   ref: Section
 }
 
-export default class GridDraggable extends Component<DraggableProps, DraggableState> {
+class GridDraggable extends Component<DraggableProps, DraggableState> {
   constructor(props: DraggableProps) {
     super(props);
     (this: any).swapGrid = this.swapGrid.bind(this);
@@ -248,4 +250,5 @@ export default class GridDraggable extends Component<DraggableProps, DraggableSt
   }
 }
 
+export default DragDropContext(HTML5Backend)(GridDraggable);
 export {default as Section} from './section';

--- a/src/section.js
+++ b/src/section.js
@@ -105,7 +105,7 @@ export default class Section extends React.Component<SectionProps, SectionState>
 
   setBounding() {
     const {setBounding, gridKey} = this.props;
-    setBounding(gridKey, this.refs.grid.parentNode.getBoundingClientRect(), this);
+    setBounding(gridKey, this.grid.parentNode.getBoundingClientRect(), this);
   }
 
   match = () => {
@@ -129,7 +129,7 @@ export default class Section extends React.Component<SectionProps, SectionState>
       dragStyle,
       handle
     } = this.props;
-    
+
     let wrappedChildren = children;
     const {dragging} = this.state;
 
@@ -140,7 +140,7 @@ export default class Section extends React.Component<SectionProps, SectionState>
 
     return (
       <div
-        ref="grid"
+        ref={grid => { this.grid = grid }}
         role="draggable-grid"
         data-grid-key={gridKey}
         className={className}

--- a/src/section.js
+++ b/src/section.js
@@ -217,7 +217,6 @@ class Section extends React.Component<SectionProps, SectionState> {
     } = this.props;
 
     let wrappedChildren = children;
-    // const {dragging} = this.state;
 
     if (typeof children === 'function') {
       const renderedChildren = children(this.state)

--- a/src/section.js
+++ b/src/section.js
@@ -28,6 +28,12 @@ type SectionState = {
   data: ?ReactDraggableCallbackData
 }
 
+const childrenBlockStyle = {
+  left: 0,
+  position: 'absolute',
+  top: 0,
+  zIndex: 200,
+};
 
 export default class Section extends React.Component<SectionProps, SectionState> {
   constructor(props: SectionProps) {
@@ -156,10 +162,7 @@ export default class Section extends React.Component<SectionProps, SectionState>
           <div
             style={dragging && {
               ...dragStyle,
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              zIndex:  200
+              ...childrenBlockStyle,
             }}
             className={dragging ? dragClassName : null}>
             {wrappedChildren}

--- a/src/section.js
+++ b/src/section.js
@@ -74,11 +74,11 @@ const dropTargetSpec = {
       return;
     }
 
-    // TODO(fredalai)
-    // const item = monitor.getItem();
-    // const { gridKey: fromKey } = item;
-    // const { swapGrid } = props;
-    // swapGrid(data, fromKey);
+    const item = monitor.getItem();
+    const { gridKey: fromKey } = item;
+    const { gridKey: toKey } = props;
+
+    props.swapGrid(fromKey, toKey);
 
     return { moved: true };
   },

--- a/src/section.js
+++ b/src/section.js
@@ -1,6 +1,8 @@
 // @flow
 import * as React from 'react';
-import Draggable from 'react-draggable';
+import { DragSource, DropTarget } from 'react-dnd';
+import { getEmptyImage } from 'react-dnd-html5-backend';
+import flow from 'lodash/flow';
 import type {ReactDraggableCallbackData} from './types';
 const noop = (arg: any) => (arg: any); // eslint-disable-line
 
@@ -28,6 +30,60 @@ type SectionState = {
   data: ?ReactDraggableCallbackData
 }
 
+function dragSourceCollect(connect, monitor) {
+  return {
+    // Call this function inside render()
+    // to let React DnD handle the drag events:
+    connectDragSource: connect.dragSource(),
+    // You can ask the monitor about the current drag state:
+    isDragging: monitor.isDragging(),
+  }
+}
+
+const dragSourceSpec = {
+  beginDrag(props) {
+    return {
+      ...props,
+    }
+  },
+};
+
+function dropTargetCollect(connect, monitor) {
+  return {
+    // Call this function inside render()
+    // to let React DnD handle the drag events:
+    connectDropTarget: connect.dropTarget(),
+    // You can ask the monitor about the current drag state:
+    isOver: monitor.isOver(),
+    isOverCurrent: monitor.isOver({ shallow: true }),
+    canDrop: monitor.canDrop(),
+    itemType: monitor.getItemType(),
+  }
+}
+
+const dropTargetSpec = {
+  canDrop(props, monitor) {
+    const item = monitor.getItem();
+
+    return item.gridKey !== props.gridKey;
+  },
+  drop(props, monitor) {
+    if (monitor.didDrop()) {
+      // If you want, you can check whether some nested
+      // target already handled drop
+      return;
+    }
+
+    // TODO(fredalai)
+    // const item = monitor.getItem();
+    // const { gridKey: fromKey } = item;
+    // const { swapGrid } = props;
+    // swapGrid(data, fromKey);
+
+    return { moved: true };
+  },
+}
+
 const childrenBlockStyle = {
   left: 0,
   position: 'absolute',
@@ -35,7 +91,7 @@ const childrenBlockStyle = {
   zIndex: 200,
 };
 
-export default class Section extends React.Component<SectionProps, SectionState> {
+class Section extends React.Component<SectionProps, SectionState> {
   constructor(props: SectionProps) {
     super(props);
 
@@ -97,6 +153,17 @@ export default class Section extends React.Component<SectionProps, SectionState>
   }
 
   componentDidMount() {
+    const { connectDragPreview } = this.props
+    if (connectDragPreview) {
+      // Use empty image as a drag preview so browsers don't draw it
+      // and we can draw whatever we want on the custom drag layer instead.
+      connectDragPreview(getEmptyImage(), {
+        // IE fallback: specify that we'd rather screenshot the node
+        // when it already knows it's being dragged so we can hide it with CSS.
+        captureDraggingState: true,
+      })
+    }
+
     const {container} = this.props;
     container.addEventListener('mousedown', this.setBounding);
     window.addEventListener('resize', this.setBounding);
@@ -133,42 +200,45 @@ export default class Section extends React.Component<SectionProps, SectionState>
       style,
       dragClassName,
       dragStyle,
-      handle
+      handle,
+      connectDropTarget,
+      connectDragSource,
+      isDragging,
     } = this.props;
 
     let wrappedChildren = children;
-    const {dragging} = this.state;
+    // const {dragging} = this.state;
 
     if (typeof children === 'function') {
       const renderedChildren = children(this.state)
       wrappedChildren = renderedChildren && React.Children.only(renderedChildren)
     }
 
-    return (
+    return connectDragSource(connectDropTarget(
       <div
         ref={grid => { this.grid = grid }}
         role="draggable-grid"
         data-grid-key={gridKey}
         className={className}
-        style={{...style, position: 'relative'}}>
-        {dragging && wrappedChildren}
-        <Draggable
-          defaultPosition={{x: 0, y: 0}}
-          position={dragging ? null : {x: 0, y: 0}}
+        style={{...style, position: 'relative'}}
+      >
+        <div
+          className={isDragging ? dragClassName : null}
+          draggable
           handle={handle}
-          onStart={this.handleStart}
           onDrag={this.handleDrag}
-          onStop={this.handleStop}>
-          <div
-            style={dragging && {
-              ...dragStyle,
-              ...childrenBlockStyle,
-            }}
-            className={dragging ? dragClassName : null}>
-            {wrappedChildren}
-          </div>
-        </Draggable>
+          onDragStart={this.handleStart}
+          onDrop={this.handleStop}
+          style={isDragging ? { ...dragStyle, ...childrenBlockStyle } : {}}
+        >
+          {wrappedChildren}
+        </div>
       </div>
-    );
+    ));
   }
 }
+
+export default flow(
+  DragSource('SECTION', dragSourceSpec, dragSourceCollect),
+  DropTarget('SECTION', dropTargetSpec, dropTargetCollect)
+)(Section)

--- a/src/section.js
+++ b/src/section.js
@@ -115,8 +115,12 @@ class Section extends React.Component<SectionProps, SectionState> {
     dragStop: noop
   };
 
+  getNodeByEventTarget(e) {
+    return findDOMNode(e.target);
+  }
+
   handleStart(e: MouseEvent) {
-    const data = findDOMNode(e.target);
+    const data = this.getNodeByEventTarget(e);
     this.setState({dragging: true});
     this.props.dragStart(e, data);
   }

--- a/src/section.js
+++ b/src/section.js
@@ -125,7 +125,11 @@ class Section extends React.Component<SectionProps, SectionState> {
     this.props.dragStart(e, data);
   }
 
-  handleDrag(e: MouseEvent, data: ReactDraggableCallbackData) {
+  handleDrag(e: MouseEvent) {
+    const node = this.getNodeByEventTarget(e);
+    const nodeBoundingClientRect = node.getBoundingClientRect();
+    const { x = 0, y = 0 } = nodeBoundingClientRect;
+    const data = { node, x, y };
     const {onDrag, getMatchGrid} = this.props;
     const match = getMatchGrid(data);
     onDrag(e, data, match);

--- a/src/section.js
+++ b/src/section.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { findDOMNode } from 'react-dom';
 import { DragSource, DropTarget } from 'react-dnd';
 import { getEmptyImage } from 'react-dnd-html5-backend';
 import flow from 'lodash/flow';
@@ -114,7 +115,8 @@ class Section extends React.Component<SectionProps, SectionState> {
     dragStop: noop
   };
 
-  handleStart(e: MouseEvent, data: ReactDraggableCallbackData) {
+  handleStart(e: MouseEvent) {
+    const data = findDOMNode(e.target);
     this.setState({dragging: true});
     this.props.dragStart(e, data);
   }

--- a/src/section.js
+++ b/src/section.js
@@ -135,16 +135,16 @@ class Section extends React.Component<SectionProps, SectionState> {
     onDrag(e, data, match);
   }
 
-  handleStop(e: MouseEvent, data: ReactDraggableCallbackData) {
+  handleStop(e: MouseEvent) {
+    const data = this.getNodeByEventTarget(e);
     const {dragStop} = this.props;
 
     // reset bounding
     this.setBounding();
     dragStop(e, data);
 
-    // swap when stop!
-    // $FlowFixMe
-    const grandParentNode = ((data.node.parentNode: HTMLElement).parentNode: HTMLElement);
+    // TODO(fredalai): Need to make sure have another way to get parentNode since someone situation will get the wrong
+    const grandParentNode = (((data.parentNode: HTMLElement).parentNode: HTMLElement).parentNode: HTMLElement);
     const fromKey = grandParentNode.children[0].getAttribute('data-grid-key');
     this.setState({
       dragging: false,


### PR DESCRIPTION
This PR not yet ready.

Spec: Use React Dnd instead of React-Draggable library.

Still have some problem/improvement items not yet resolve:
- Avoid use the way like: data.parentNode.parentNode (but not yet fix) since someone situation will get the wrong.
- [Improvement item] Use react hooks to implement
- Sort out source code

Note:
 - React Dnd's Hooks-Based API is unstable currently. (To evaluate it from the perspective of the project, this is why I did not choose to use it.)
